### PR TITLE
Expand controls to specific rules and variables during profile resolution

### DIFF
--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -6,6 +6,7 @@ import os.path
 from glob import glob
 
 import ssg.build_yaml
+import ssg.controls
 
 
 def create_parser():
@@ -26,6 +27,11 @@ def create_parser():
     parser.add_argument(
         "--output", "-o", default="{name}.profile",
         help="The template for saving processed profile files."
+    )
+    parser.add_argument(
+        "--controls-dir",
+        help="Directory that contains control files with policy controls. "
+        "e.g.: ~/scap-security-guide/controls",
     )
     return parser
 
@@ -67,11 +73,15 @@ def main():
     args = parser.parse_args()
     env_yaml = get_env_yaml(args.build_config_yaml, args.product_yaml)
 
+    if args.controls_dir:
+        controls_manager = ssg.controls.ControlsManager(args.controls_dir, env_yaml)
+        controls_manager.load()
+
     profile_files = get_profile_files_from_root(env_yaml, args.product_yaml)
     profile_files.extend(args.profile_file)
     profiles = make_name_to_profile_mapping(profile_files, env_yaml)
     for pname in profiles:
-        profiles[pname].resolve(profiles)
+        profiles[pname].resolve(profiles, controls_manager)
 
     for name, p in profiles.items():
         p.dump_yaml(args.output.format(name=name))

--- a/build-scripts/compile_profiles.py
+++ b/build-scripts/compile_profiles.py
@@ -8,49 +8,6 @@ from glob import glob
 import ssg.build_yaml
 
 
-class ResolvableProfile(ssg.build_yaml.Profile):
-    def __init__(self, * args, ** kwargs):
-        super(ResolvableProfile, self).__init__(* args, ** kwargs)
-        self.resolved = False
-
-    def resolve(self, all_profiles):
-        if self.resolved:
-            return
-
-        resolved_selections = set(self.selected)
-        if self.extends:
-            if self.extends not in all_profiles:
-                msg = (
-                    "Profile {name} extends profile {extended}, but"
-                    "only profiles {known_profiles} are available for resolution."
-                    .format(name=self.id_, extended=self.extends,
-                            profiles=list(all_profiles.keys())))
-                raise RuntimeError(msg)
-            extended_profile = all_profiles[self.extends]
-            extended_profile.resolve(all_profiles)
-
-            extended_selects = set(extended_profile.selected)
-            resolved_selections.update(extended_selects)
-
-            updated_variables = dict(extended_profile.variables)
-            updated_variables.update(self.variables)
-            self.variables = updated_variables
-
-            updated_refinements = dict(extended_profile.refine_rules)
-            updated_refinements.update(self.refine_rules)
-            self.refine_rules = updated_refinements
-
-        for uns in self.unselected:
-            resolved_selections.discard(uns)
-
-        self.unselected = []
-        self.extends = None
-
-        self.selected = sorted(resolved_selections)
-
-        self.resolved = True
-
-
 def create_parser():
     parser = argparse.ArgumentParser()
     parser.add_argument("profile_file", nargs="*")
@@ -77,7 +34,7 @@ def make_name_to_profile_mapping(profile_files, env_yaml):
     name_to_profile = {}
     for f in profile_files:
         try:
-            p = ResolvableProfile.from_yaml(f, env_yaml)
+            p = ssg.build_yaml.ResolvableProfile.from_yaml(f, env_yaml)
             name_to_profile[p.id_] = p
         except Exception as exc:
             # The profile is probably doc-incomplete

--- a/cmake/SSGCommon.cmake
+++ b/cmake/SSGCommon.cmake
@@ -118,7 +118,7 @@ macro(ssg_build_shorthand_xml PRODUCT)
     add_custom_command(
         OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/profiles"
         COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_CURRENT_BINARY_DIR}/profiles"
-        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_profiles.py" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" -o "${CMAKE_CURRENT_BINARY_DIR}/profiles/{name}.profile"
+        COMMAND env "PYTHONPATH=$ENV{PYTHONPATH}" "${PYTHON_EXECUTABLE}" "${SSG_BUILD_SCRIPTS}/compile_profiles.py" --controls-dir "${CMAKE_SOURCE_DIR}/controls" --build-config-yaml "${CMAKE_BINARY_DIR}/build_config.yml" --product-yaml "${CMAKE_CURRENT_SOURCE_DIR}/product.yml" -o "${CMAKE_CURRENT_BINARY_DIR}/profiles/{name}.profile"
         DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/profiles/"
         COMMENT "[${PRODUCT}-content] compiling profiles"
     )

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -350,7 +350,9 @@ class ResolvableProfile(Profile):
                 for control_id in controls_list:
                     control = controls_manager.get_control(policy_id, control_id)
                     resolved_selections |= set(control.rules)
-                    self.variables.update(control.variables)
+                    for varname, value in control.variables.items():
+                        if varname not in self.variables:
+                            self.variables[varname] = value
 
         if self.extends:
             if self.extends not in all_profiles:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -340,26 +340,29 @@ class ResolvableProfile(Profile):
         super(ResolvableProfile, self).__init__(* args, ** kwargs)
         self.resolved = False
 
+    def resolve_controls(self, controls_manager):
+        for policy_id, controls in self.policies.items():
+            if isinstance(controls, list):
+                controls_list = [controls_manager.get_control(policy_id, control_id) for control_id in controls]
+            elif controls == "all":
+                controls_list = controls_manager.get_all_controls(policy_id)
+            else:
+                msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls, profile_id=self.id_)
+                raise ValueError(msg)
+            for control in controls_list:
+                self.selected.extend(control.rules)
+                for varname, value in control.variables.items():
+                    if varname not in self.variables:
+                        self.variables[varname] = value
+
     def resolve(self, all_profiles, controls_manager=None):
         if self.resolved:
             return
 
-        resolved_selections = set(self.selected)
-
         if self.policies:
-            for policy_id, controls in self.policies.items():
-                if isinstance(controls, list):
-                    controls_list = [controls_manager.get_control(policy_id, control_id) for control_id in controls]
-                elif controls == "all":
-                    controls_list = controls_manager.get_all_controls(policy_id)
-                else:
-                    msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls, profile_id=self.id_)
-                    raise ValueError(msg)
-                for control in controls_list:
-                    resolved_selections |= set(control.rules)
-                    for varname, value in control.variables.items():
-                        if varname not in self.variables:
-                            self.variables[varname] = value
+            self.resolve_controls(controls_manager)
+
+        resolved_selections = set(self.selected)
 
         if self.extends:
             if self.extends not in all_profiles:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -191,10 +191,11 @@ class Profile(object):
             id_ = required_key(item, "id")
             controls = required_key(item, "controls")
             if not isinstance(controls, list):
-                msg = ("Policy {id_} contains invalid controls list {controls}."
-                    .format(id_=id_, controls=str(controls))
-                    )
-                raise ValueError(msg)
+                if controls != "all":
+                    msg = ("Policy {id_} contains invalid controls list {controls}."
+                        .format(id_=id_, controls=str(controls))
+                        )
+                    raise ValueError(msg)
             self.policies[id_] = controls
 
     def to_xml_element(self):
@@ -346,9 +347,15 @@ class ResolvableProfile(Profile):
         resolved_selections = set(self.selected)
 
         if self.policies:
-            for policy_id, controls_list in self.policies.items():
-                for control_id in controls_list:
-                    control = controls_manager.get_control(policy_id, control_id)
+            for policy_id, controls in self.policies.items():
+                if isinstance(controls, list):
+                    controls_list = [controls_manager.get_control(policy_id, control_id) for control_id in controls]
+                elif controls == "all":
+                    controls_list = controls_manager.get_all_controls(policy_id)
+                else:
+                    msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls, profile_id=self.id_)
+                    raise ValueError(msg)
+                for control in controls_list:
                     resolved_selections |= set(control.rules)
                     for varname, value in control.variables.items():
                         if varname not in self.variables:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -334,6 +334,49 @@ class Profile(object):
         return profile
 
 
+class ResolvableProfile(Profile):
+    def __init__(self, * args, ** kwargs):
+        super(ResolvableProfile, self).__init__(* args, ** kwargs)
+        self.resolved = False
+
+    def resolve(self, all_profiles):
+        if self.resolved:
+            return
+
+        resolved_selections = set(self.selected)
+        if self.extends:
+            if self.extends not in all_profiles:
+                msg = (
+                    "Profile {name} extends profile {extended}, but"
+                    "only profiles {known_profiles} are available for resolution."
+                    .format(name=self.id_, extended=self.extends,
+                            profiles=list(all_profiles.keys())))
+                raise RuntimeError(msg)
+            extended_profile = all_profiles[self.extends]
+            extended_profile.resolve(all_profiles)
+
+            extended_selects = set(extended_profile.selected)
+            resolved_selections.update(extended_selects)
+
+            updated_variables = dict(extended_profile.variables)
+            updated_variables.update(self.variables)
+            self.variables = updated_variables
+
+            updated_refinements = dict(extended_profile.refine_rules)
+            updated_refinements.update(self.refine_rules)
+            self.refine_rules = updated_refinements
+
+        for uns in self.unselected:
+            resolved_selections.discard(uns)
+
+        self.unselected = []
+        self.extends = None
+
+        self.selected = sorted(resolved_selections)
+
+        self.resolved = True
+
+
 class Value(object):
     """Represents XCCDF Value
     """

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -332,18 +332,15 @@ class ResolvableProfile(Profile):
         self.resolved = False
         self.resolved_selections = set()
 
-    def _controls_to_items(self, controls_manager, policy_id, control_id_list):
-        items = Control()
-        for control_id in control_id_list:
-            new_control = controls_manager.get_control(policy_id, control_id)
-            items.rules.extend(new_control.rules)
-            items.variables.update(new_control.variables)
-        items.rules = list(set(items.rules))
+    def _controls_ids_to_controls(self, controls_manager, policy_id, control_id_list):
+        items = [controls_manager.get_control(policy_id, cid) for cid in control_id_list]
         return items
 
-    def _policy_to_items(self, controls_manager, policy_id):
-        control_id_list = [c.id for c in controls_manager.get_all_controls(policy_id)]
-        return self._controls_to_items(controls_manager, policy_id, control_id_list)
+    def _merge_control(self, control):
+        self.selected.extend(control.rules)
+        for varname, value in control.variables.items():
+            if varname not in self.variables:
+                self.variables[varname] = value
 
     def resolve_controls(self, controls_manager):
         pass
@@ -406,31 +403,29 @@ class ProfileWithSeparatePolicies(ResolvableProfile):
     def _parse_policies(self, policies_yaml):
         for item in policies_yaml:
             id_ = required_key(item, "id")
-            controls = required_key(item, "controls")
-            if not isinstance(controls, list):
-                if controls != "all":
+            controls_ids = required_key(item, "controls")
+            if not isinstance(controls_ids, list):
+                if controls_ids != "all":
                     msg = ("Policy {id_} contains invalid controls list {controls}."
-                        .format(id_=id_, controls=str(controls))
+                        .format(id_=id_, controls=str(controls_ids))
                         )
                     raise ValueError(msg)
-            self.policies[id_] = controls
+            self.policies[id_] = controls_ids
 
     def resolve_controls(self, controls_manager):
-        for policy_id, controls in self.policies.items():
-            to_expand = Control()
+        for policy_id, controls_ids in self.policies.items():
+            controls = []
 
-            if isinstance(controls, list):
-                to_expand = self._controls_to_items(controls_manager, policy_id, controls)
-            elif controls == "all":
-                to_expand = self._policy_to_items(controls_manager, policy_id)
+            if isinstance(controls_ids, list):
+                controls = self._controls_ids_to_controls(controls_manager, policy_id, controls_ids)
+            elif controls_ids == "all":
+                controls = controls_manager.get_all_controls(policy_id)
             else:
-                msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls, profile_id=self.id_)
+                msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls_ids, profile_id=self.id_)
                 raise ValueError(msg)
 
-            self.selected.extend(to_expand.rules)
-            for varname, value in to_expand.variables.items():
-                if varname not in self.variables:
-                    self.variables[varname] = value
+            for c in controls:
+                self._merge_control(c)
 
     def extend_by(self, extended_profile):
         self.policies.update(extended_profile.policies)
@@ -450,16 +445,16 @@ class ProfileWithInlinePolicies(ResolvableProfile):
             super(ProfileWithInlinePolicies, self).apply_selection(item)
 
     def resolve_controls(self, controls_manager):
-        for policy_id, controls in self.controls_by_policy.items():
-            if "all" in controls:
-                to_expand = self._policy_to_items(controls_manager, policy_id)
-            else:
-                to_expand = self._controls_to_items(controls_manager, policy_id, controls)
+        for policy_id, controls_ids in self.controls_by_policy.items():
+            controls = []
 
-            self.selected.extend(to_expand.rules)
-            for varname, value in to_expand.variables.items():
-                if varname not in self.variables:
-                    self.variables[varname] = value
+            if "all" in controls_ids:
+                controls = controls_manager.get_all_controls(policy_id)
+            else:
+                controls = self._controls_ids_to_controls(controls_manager, policy_id, controls_ids)
+
+            for c in controls:
+                self._merge_control(c)
 
 
 class Value(object):

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -344,6 +344,13 @@ class ResolvableProfile(Profile):
             return
 
         resolved_selections = set(self.selected)
+
+        if self.policies:
+            for policy_id, controls_list in self.policies.items():
+                for control_id in controls_list:
+                    control = controls_manager.get_control(policy_id, control_id)
+                    resolved_selections |= set(control.rules)
+
         if self.extends:
             if self.extends not in all_profiles:
                 msg = (

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -350,6 +350,7 @@ class ResolvableProfile(Profile):
                 for control_id in controls_list:
                     control = controls_manager.get_control(policy_id, control_id)
                     resolved_selections |= set(control.rules)
+                    self.variables.update(control.variables)
 
         if self.extends:
             if self.extends not in all_profiles:

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -339,7 +339,7 @@ class ResolvableProfile(Profile):
         super(ResolvableProfile, self).__init__(* args, ** kwargs)
         self.resolved = False
 
-    def resolve(self, all_profiles):
+    def resolve(self, all_profiles, controls_manager=None):
         if self.resolved:
             return
 
@@ -353,7 +353,7 @@ class ResolvableProfile(Profile):
                             profiles=list(all_profiles.keys())))
                 raise RuntimeError(msg)
             extended_profile = all_profiles[self.extends]
-            extended_profile.resolve(all_profiles)
+            extended_profile.resolve(all_profiles, controls_manager)
 
             extended_selects = set(extended_profile.selected)
             resolved_selections.update(extended_selects)

--- a/ssg/build_yaml.py
+++ b/ssg/build_yaml.py
@@ -16,6 +16,7 @@ from .constants import STIG_PLATFORM_ID_MAP
 from .constants import XCCDF_REFINABLE_PROPERTIES
 from .rules import get_rule_dir_id, get_rule_dir_yaml, is_rule_dir
 from .rule_yaml import parse_prodtype
+from .controls import Control
 
 from .checks import is_cce_format_valid, is_cce_value_valid
 from .yaml import DocumentationNotComplete, open_and_expand, open_and_macro_expand
@@ -111,7 +112,17 @@ class Profile(object):
         self.unselected = []
         self.variables = dict()
         self.refine_rules = defaultdict(list)
-        self.policies = {}
+
+    def read_yaml_contents(self, yaml_contents):
+        self.title = required_key(yaml_contents, "title")
+        del yaml_contents["title"]
+        self.description = required_key(yaml_contents, "description")
+        del yaml_contents["description"]
+        self.extends = yaml_contents.pop("extends", None)
+        selection_entries = required_key(yaml_contents, "selections")
+        if selection_entries:
+            self._parse_selections(selection_entries)
+        del yaml_contents["selections"]
 
     @classmethod
     def from_yaml(cls, yaml_file, env_yaml=None):
@@ -122,18 +133,7 @@ class Profile(object):
         basename, _ = os.path.splitext(os.path.basename(yaml_file))
 
         profile = cls(basename)
-        profile.title = required_key(yaml_contents, "title")
-        del yaml_contents["title"]
-        profile.description = required_key(yaml_contents, "description")
-        del yaml_contents["description"]
-        profile.extends = yaml_contents.pop("extends", None)
-        selection_entries = required_key(yaml_contents, "selections")
-        if selection_entries:
-            profile._parse_selections(selection_entries)
-        del yaml_contents["selections"]
-        policies = yaml_contents.pop("policies", None)
-        if policies:
-            profile._parse_policies(policies)
+        profile.read_yaml_contents(yaml_contents)
 
         if yaml_contents:
             raise RuntimeError("Unparsed YAML data in '%s'.\n\n%s"
@@ -166,37 +166,28 @@ class Profile(object):
 
     def _parse_selections(self, entries):
         for item in entries:
-            if "." in item:
-                rule, refinement = item.split(".", 1)
-                property_, value = refinement.split("=", 1)
-                if property_ not in XCCDF_REFINABLE_PROPERTIES:
-                    msg = ("Property '{property_}' cannot be refined. "
-                           "Rule properties that can be refined are {refinables}. "
-                           "Fix refinement '{rule_id}.{property_}={value}' in profile '{profile}'."
-                           .format(property_=property_, refinables=XCCDF_REFINABLE_PROPERTIES,
-                                   rule_id=rule, value=value, profile=self.id_)
-                           )
-                    raise ValueError(msg)
-                self.refine_rules[rule].append((property_, value))
-            elif "=" in item:
-                varname, value = item.split("=", 1)
-                self.variables[varname] = value
-            elif item.startswith("!"):
-                self.unselected.append(item[1:])
-            else:
-                self.selected.append(item)
+            self.apply_selection(item)
 
-    def _parse_policies(self, policies_yaml):
-        for item in policies_yaml:
-            id_ = required_key(item, "id")
-            controls = required_key(item, "controls")
-            if not isinstance(controls, list):
-                if controls != "all":
-                    msg = ("Policy {id_} contains invalid controls list {controls}."
-                        .format(id_=id_, controls=str(controls))
-                        )
-                    raise ValueError(msg)
-            self.policies[id_] = controls
+    def apply_selection(self, item):
+        if "." in item:
+            rule, refinement = item.split(".", 1)
+            property_, value = refinement.split("=", 1)
+            if property_ not in XCCDF_REFINABLE_PROPERTIES:
+                msg = ("Property '{property_}' cannot be refined. "
+                       "Rule properties that can be refined are {refinables}. "
+                       "Fix refinement '{rule_id}.{property_}={value}' in profile '{profile}'."
+                       .format(property_=property_, refinables=XCCDF_REFINABLE_PROPERTIES,
+                               rule_id=rule, value=value, profile=self.id_)
+                       )
+                raise ValueError(msg)
+            self.refine_rules[rule].append((property_, value))
+        elif "=" in item:
+            varname, value = item.split("=", 1)
+            self.variables[varname] = value
+        elif item.startswith("!"):
+            self.unselected.append(item[1:])
+        else:
+            self.selected.append(item)
 
     def to_xml_element(self):
         element = ET.Element('Profile')
@@ -335,64 +326,141 @@ class Profile(object):
         return profile
 
 
+class ProfileWithSeparatePolicies(Profile):
+    def __init__(self, * args, ** kwargs):
+        super(ProfileWithSeparatePolicies, self).__init__(* args, ** kwargs)
+        self.policies = {}
+
+    def read_yaml_contents(self, yaml_contents):
+        policies = yaml_contents.pop("policies", None)
+        if policies:
+            self._parse_policies(policies)
+        super(ProfileWithSeparatePolicies, self).read_yaml_contents(yaml_contents)
+
+    def _parse_policies(self, policies_yaml):
+        for item in policies_yaml:
+            id_ = required_key(item, "id")
+            controls = required_key(item, "controls")
+            if not isinstance(controls, list):
+                if controls != "all":
+                    msg = ("Policy {id_} contains invalid controls list {controls}."
+                        .format(id_=id_, controls=str(controls))
+                        )
+                    raise ValueError(msg)
+            self.policies[id_] = controls
+
+    def resolve_controls(self, controls_manager):
+        for policy_id, controls in self.policies.items():
+            to_expand = Control()
+
+            if isinstance(controls, list):
+                to_expand = self._controls_to_items(controls_manager, policy_id, controls)
+            elif controls == "all":
+                to_expand = self._policy_to_items(controls_manager, policy_id)
+            else:
+                msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls, profile_id=self.id_)
+                raise ValueError(msg)
+
+            self.selected.extend(to_expand.rules)
+            for varname, value in to_expand.variables.items():
+                if varname not in self.variables:
+                    self.variables[varname] = value
+
+    def extend_by(self, extended_profile):
+        self.policies.update(extended_profile.policies)
+        super(ProfileWithSeparatePolicies, self).extend_by(extended_profile)
+
+
+class ProfileWithInlinePolicies(Profile):
+    def __init__(self, * args, ** kwargs):
+        super(ProfileWithInlinePolicies, self).__init__(* args, ** kwargs)
+        self.controls_by_policy = defaultdict(list)
+
+    def apply_selection(self, item):
+        if ":" in item:
+            policy_id, control_id = item.split(":", 1)
+            self.controls_by_policy[policy_id].append(control_id)
+        else:
+            super(ProfileWithInlinePolicies, self).apply_selection(item)
+
+    def resolve_controls(self, controls_manager):
+        for policy_id, controls in self.controls_by_policy.items():
+            if "all" in controls:
+                to_expand = self._policy_to_items(controls_manager, policy_id)
+            else:
+                to_expand = self._controls_to_items(controls_manager, policy_id, controls)
+
+            self.selected.extend(to_expand.rules)
+            for varname, value in to_expand.variables.items():
+                if varname not in self.variables:
+                    self.variables[varname] = value
+
+
 class ResolvableProfile(Profile):
     def __init__(self, * args, ** kwargs):
         super(ResolvableProfile, self).__init__(* args, ** kwargs)
         self.resolved = False
+        self.resolved_selections = set()
+
+    def _control_to_items(self, controls_manager, policy_id, control_id):
+        return controls_manager.get_control(policy_id, control_id)
+
+    def _controls_to_items(self, controls_manager, policy_id, control_id_list):
+        items = Control()
+        for control_id in control_id_list:
+            new_control = self._control_to_items(controls_manager, policy_id, control_id)
+            items.rules.extend(new_control.rules)
+            items.variables.update(new_control.variables)
+        items.rules = list(set(items.rules))
+        return items
+
+    def _policy_to_items(self, controls_manager, policy_id):
+        control_id_list = controls_manager.get_all_controls(policy_id)
+        return self._controls_to_items(controls_manager, policy_id, control_id_list)
 
     def resolve_controls(self, controls_manager):
-        for policy_id, controls in self.policies.items():
-            if isinstance(controls, list):
-                controls_list = [controls_manager.get_control(policy_id, control_id) for control_id in controls]
-            elif controls == "all":
-                controls_list = controls_manager.get_all_controls(policy_id)
-            else:
-                msg = "Unknown policy content {content} in profile {profile_id}".format(content=controls, profile_id=self.id_)
-                raise ValueError(msg)
-            for control in controls_list:
-                self.selected.extend(control.rules)
-                for varname, value in control.variables.items():
-                    if varname not in self.variables:
-                        self.variables[varname] = value
+        pass
+
+    def extend_by(self, extended_profile):
+        extended_selects = set(extended_profile.selected)
+        self.resolved_selections.update(extended_selects)
+
+        updated_variables = dict(extended_profile.variables)
+        updated_variables.update(self.variables)
+        self.variables = updated_variables
+
+        updated_refinements = dict(extended_profile.refine_rules)
+        updated_refinements.update(self.refine_rules)
+        self.refine_rules = updated_refinements
 
     def resolve(self, all_profiles, controls_manager=None):
         if self.resolved:
             return
 
-        if self.policies:
-            self.resolve_controls(controls_manager)
+        self.resolve_controls(controls_manager)
 
-        resolved_selections = set(self.selected)
+        self.resolved_selections = set(self.selected)
 
         if self.extends:
             if self.extends not in all_profiles:
                 msg = (
-                    "Profile {name} extends profile {extended}, but"
+                    "Profile {name} extends profile {extended}, but "
                     "only profiles {known_profiles} are available for resolution."
                     .format(name=self.id_, extended=self.extends,
-                            profiles=list(all_profiles.keys())))
+                            known_profiles=list(all_profiles.keys())))
                 raise RuntimeError(msg)
             extended_profile = all_profiles[self.extends]
             extended_profile.resolve(all_profiles, controls_manager)
 
-            extended_selects = set(extended_profile.selected)
-            resolved_selections.update(extended_selects)
-
-            updated_variables = dict(extended_profile.variables)
-            updated_variables.update(self.variables)
-            self.variables = updated_variables
-
-            updated_refinements = dict(extended_profile.refine_rules)
-            updated_refinements.update(self.refine_rules)
-            self.refine_rules = updated_refinements
+            self.extend_by(extended_profile)
 
         for uns in self.unselected:
-            resolved_selections.discard(uns)
+            self.resolved_selections.discard(uns)
 
         self.unselected = []
         self.extends = None
 
-        self.selected = sorted(resolved_selections)
+        self.selected = sorted(self.resolved_selections)
 
         self.resolved = True
 

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -77,6 +77,8 @@ class ControlsManager():
         self.policies = {}
 
     def load(self):
+        if not os.path.exists(self.controls_dir):
+            return
         for filename in os.listdir(self.controls_dir):
             logging.info("Found file %s" % (filename))
             filepath = os.path.join(self.controls_dir, filename)

--- a/ssg/controls.py
+++ b/ssg/controls.py
@@ -94,3 +94,11 @@ class ControlsManager():
             raise ValueError(msg)
         control = policy.get_control(control_id)
         return control
+
+    def get_all_controls(self, policy_id):
+        try:
+            policy = self.policies[policy_id]
+        except KeyError:
+            msg = "policy '%s' doesn't exist" % (policy_id)
+            raise ValueError(msg)
+        return policy.controls.values()

--- a/tests/unit/ssg-module/data/profiles_dir/abcd-all-inline.profile
+++ b/tests/unit/ssg-module/data/profiles_dir/abcd-all-inline.profile
@@ -1,0 +1,8 @@
+documentation_complete: true
+title: ABCD ALL for Red Hat Enterprise Linux 9
+description: >-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+selections:
+  - abcd:all
+  - security_patches_uptodate

--- a/tests/unit/ssg-module/data/profiles_dir/abcd-all.profile
+++ b/tests/unit/ssg-module/data/profiles_dir/abcd-all.profile
@@ -1,0 +1,10 @@
+documentation_complete: true
+title: ABCD ALL for Red Hat Enterprise Linux 9
+description: >-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+policies:
+- id: abcd
+  controls: all
+selections:
+  - security_patches_uptodate

--- a/tests/unit/ssg-module/data/profiles_dir/abcd-high-inline.profile
+++ b/tests/unit/ssg-module/data/profiles_dir/abcd-high-inline.profile
@@ -1,0 +1,10 @@
+documentation_complete: true
+title: ABCD High for Red Hat Enterprise Linux 8
+description: >-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+extends: abcd-low-inline
+selections:
+  - abcd:R4
+  # override setting from R4.b
+  - var_password_pam_ocredit=2

--- a/tests/unit/ssg-module/data/profiles_dir/abcd-low-inline.profile
+++ b/tests/unit/ssg-module/data/profiles_dir/abcd-low-inline.profile
@@ -1,0 +1,10 @@
+documentation_complete: true
+title: ABCD Low for Red Hat Enterprise Linux 8
+description: >-
+  This profile contains configuration checks that align to
+  the ABCD benchmark.
+selections:
+  - security_patches_uptodate
+  - abcd:R1
+  - abcd:R2
+  - abcd:R3

--- a/tests/unit/ssg-module/data/profiles_dir/abcd-low.profile
+++ b/tests/unit/ssg-module/data/profiles_dir/abcd-low.profile
@@ -1,14 +1,13 @@
- 
 documentation_complete: true
-title: ABCD High for Red Hat Enterprise Linux 8
+title: ABCD Low for Red Hat Enterprise Linux 8
 description: >-
   This profile contains configuration checks that align to
   the ABCD benchmark.
-extends: abcd-low
 policies:
 - id: abcd
   controls:
-  - R4
+  - R1
+  - R2
+  - R3
 selections:
-# override setting from R4.b
-  - var_password_pam_ocredit=2
+  - security_patches_uptodate

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -62,10 +62,13 @@ def test_controls_load_product():
     assert "cockpit_session_timeout" in c_r1.rules
 
 def test_profile_resolution():
+    env_yaml = {"product": "rhel9"}
+    controls_manager = ssg.controls.ControlsManager(controls_dir, env_yaml)
+    controls_manager.load()
     high_profile_path = os.path.join(profiles_dir, "abcd-high.profile")
     profile = ssg.build_yaml.ResolvableProfile.from_yaml(high_profile_path)
     logging.info(profile.selected)
     assert "security_patches_uptodate" in profile.selected
     all_profiles = {"abcd-high": profile}
-    profile.resolve(all_profiles)
+    profile.resolve(all_profiles, controls_manager=controls_manager)
     logging.info(profile.selected)

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -75,6 +75,7 @@ def test_profile_resolution():
     assert "sshd_set_idle_timeout" in profile.selected
     assert "accounts_tmout" in profile.selected
     assert "cockpit_session_timeout" in profile.selected
+    assert "var_accounts_tmout" in profile.variables
 
     # The rule "security_patches_uptodate" has been selected directly by profile
     # selections, not by using controls, so it should be in the resolved profile

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -67,8 +67,16 @@ def test_profile_resolution():
     controls_manager.load()
     high_profile_path = os.path.join(profiles_dir, "abcd-high.profile")
     profile = ssg.build_yaml.ResolvableProfile.from_yaml(high_profile_path)
-    logging.info(profile.selected)
-    assert "security_patches_uptodate" in profile.selected
     all_profiles = {"abcd-high": profile}
     profile.resolve(all_profiles, controls_manager=controls_manager)
-    logging.info(profile.selected)
+
+    # Profile 'abcd-high' selects controls R1, R2, R3 from 'abcd' policy,
+    # which should add the following rules to the profile:
+    assert "sshd_set_idle_timeout" in profile.selected
+    assert "accounts_tmout" in profile.selected
+    assert "cockpit_session_timeout" in profile.selected
+
+    # The rule "security_patches_uptodate" has been selected directly by profile
+    # selections, not by using controls, so it should be in the resolved profile
+    # as well.
+    assert "security_patches_uptodate" in profile.selected

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -62,28 +62,28 @@ def test_controls_load_product():
     assert "cockpit_session_timeout" in c_r1.rules
 
 
-class SeparateResolvableProfile(ssg.build_yaml.ProfileWithSeparatePolicies, ssg.build_yaml.ResolvableProfile):
-    pass
-
-
-class InlineResolvableProfile(ssg.build_yaml.ProfileWithInlinePolicies, ssg.build_yaml.ResolvableProfile):
-    pass
-
-
 def test_profile_resolution_separate():
-    profile_resolution(SeparateResolvableProfile, "abcd-low")
+    profile_resolution(ssg.build_yaml.ProfileWithSeparatePolicies, "abcd-low")
 
 
 def test_profile_resolution_extends_separate():
-    profile_resolution_extends(SeparateResolvableProfile, "abcd-low", "abcd-high")
+    profile_resolution_extends(ssg.build_yaml.ProfileWithSeparatePolicies, "abcd-low", "abcd-high")
+
+
+def test_profile_resolution_all_separate():
+    profile_resolution_all(ssg.build_yaml.ProfileWithSeparatePolicies, "abcd-all")
 
 
 def test_profile_resolution_inline():
-    profile_resolution(InlineResolvableProfile, "abcd-low-inline")
+    profile_resolution(ssg.build_yaml.ProfileWithInlinePolicies, "abcd-low-inline")
 
 
 def test_profile_resolution_extends_inline():
-    profile_resolution_extends(InlineResolvableProfile, "abcd-low-inline", "abcd-high-inline")
+    profile_resolution_extends(ssg.build_yaml.ProfileWithInlinePolicies, "abcd-low-inline", "abcd-high-inline")
+
+
+def test_profile_resolution_all_inline():
+    profile_resolution_all(ssg.build_yaml.ProfileWithInlinePolicies, "abcd-all-inline")
 
 
 def profile_resolution(cls, profile_low):
@@ -140,14 +140,13 @@ def profile_resolution_extends(cls, profile_low, profile_high):
     assert high_profile.variables["var_password_pam_ocredit"] == "2"
 
 
-@pytest.mark.skip
-def test_profile_resolution_all():
+def profile_resolution_all(cls, profile_all):
     env_yaml = {"product": "rhel9"}
     controls_manager = ssg.controls.ControlsManager(controls_dir, env_yaml)
     controls_manager.load()
-    profile_path = os.path.join(profiles_dir, "abcd-all.profile")
-    profile = ssg.build_yaml.ResolvableProfile.from_yaml(profile_path)
-    all_profiles = {"abcd-all": profile}
+    profile_path = os.path.join(profiles_dir, profile_all + ".profile")
+    profile = cls.from_yaml(profile_path)
+    all_profiles = {profile_all: profile}
     profile.resolve(all_profiles, controls_manager=controls_manager)
 
     # Profile 'abcd-all' selects all controls from 'abcd' policy,

--- a/tests/unit/ssg-module/test_controls.py
+++ b/tests/unit/ssg-module/test_controls.py
@@ -63,5 +63,9 @@ def test_controls_load_product():
 
 def test_profile_resolution():
     high_profile_path = os.path.join(profiles_dir, "abcd-high.profile")
-    profile = ssg.build_yaml.Profile.from_yaml(high_profile_path)
-    logging.info(profile)
+    profile = ssg.build_yaml.ResolvableProfile.from_yaml(high_profile_path)
+    logging.info(profile.selected)
+    assert "security_patches_uptodate" in profile.selected
+    all_profiles = {"abcd-high": profile}
+    profile.resolve(all_profiles)
+    logging.info(profile.selected)


### PR DESCRIPTION
Adds support for resolving controls to the profile resolution methods. The controls will be expanded to specific rules and variables and then saved in canonical form (so-called compiled profiles). It means that profiles will be used transparently later in the build process.