### PR TITLE
Add note and select rules for ANSSI R9

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -124,7 +124,14 @@ controls:
   - id: R9
     level: intermediary
     title: Hardware configuration
-    # rules: TBD
+    notes: >-
+      Configurations recommended for this requirement are to be performed at the BIOS level.
+      The content automation cannot really configure the BIOS, but can in some cases,
+      check settings that are visible to the OS. Like for example the NX/DX setting.
+    rules:
+    - sysctl_kernel_exec_shield
+    - bios_enable_execution_restrictions
+    - install_PAE_kernel_on_x86-32
 
   - id: R10
     level: intermediary


### PR DESCRIPTION
#### Description:

- R9 is about configuring BIOS.
  - OpenSCAP cannot change settings in BIOS, but it can check them if they are exposed to the OS.
