### PR TITLE
Select rule for R47 - dedicated partition for logs

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -556,6 +556,9 @@ controls:
   - id: R47
     level: intermediary
     title: Dedicated partition for logs
+    notes: This assumes that syslog stores its logs locally in "/var/logs/audit".
+    rules:
+      - partition_for_var_log_audit
 
   - id: R48
     level: intermediary

--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -556,7 +556,7 @@ controls:
   - id: R47
     level: intermediary
     title: Dedicated partition for logs
-    notes: This assumes that syslog stores its logs locally in "/var/logs/audit".
+    notes: This assumes that syslog stores its logs locally in "/var/log/audit".
     rules:
       - partition_for_var_log_audit
 


### PR DESCRIPTION
#### Description:

- The selected rule assumes that rsyslog stores its logs in the
default path, /var/log/audit.
- Note, the mounting point for the partition may need to be made tailorable depending on implementation of R43.

