### PR TITLE
Select rule for ANSSI R48 - Configuring the local messaging service

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -560,7 +560,8 @@ controls:
   - id: R48
     level: intermediary
     title: Configuring the local messaging service
-    # rules: TBD
+    rules:
+    - postfix_network_listening_disabled
 
   - id: R49
     level: intermediary


### PR DESCRIPTION
#### Description:

- The selected rule configures `postfix` to only accept mail from localhost.
  - The rules misses Bash remediation