### PR TITLE
ANSSI R59  - User authentication running sudo

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -674,6 +674,7 @@ controls:
     title: User authentication running sudo
     rules:
     - sudo_remove_nopasswd
+    - sudo_remove_no_authenticate
 
   - id: R60
     level: intermediary


### PR DESCRIPTION
#### Description:
* add rule sudo_remove_no_authenticate to r59
#### Rationale:
* This is another way how to circumvent authentication when using sudo.