### PR TITLE
Remove variable selector for remote_loghost_address

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -114,8 +114,9 @@ controls:
       The activities of the running system and services must be logged and
       archived on an external, non-local system.
     rules:
-    # logcollector is a placeholder for the name or IP of the system to send the logs to
-    - rsyslog_remote_loghost_address=logcollector
+    # The default remote loghost is logcollector.
+    # Change the default value to the hostname or IP of the system to send the logs to
+    - rsyslog_remote_loghost_address=default
     - rsyslog_remote_loghost
 
   - id: R8
@@ -572,8 +573,9 @@ controls:
     - partition_for_var_log_audit
 
     # Derived from DAT-NT-012 R5, these are also covered in R7
-    # logcollector is a placeholder for the name or IP of the system to send the logs to
-    - rsyslog_remote_loghost_address=logcollector
+    # The default remote loghost is logcollector.
+    # Change the default value to the hostname or IP of the system to send the logs to
+    - rsyslog_remote_loghost_address=default
     - rsyslog_remote_loghost
 
     # Derived from DAT-NT-012 R12


### PR DESCRIPTION
#### Description:

- Remove selector for `rsyslog_remote_loghost_address`.

#### Rationale:

- The default value is `logcollector` not the selector.

