### PR TITLE
Select sshd_set_keepalive in ANSSI R29.

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -461,6 +461,7 @@ controls:
     - accounts_tmout
     - sshd_set_idle_timeout
     - sshd_idle_timeout_value=5_minutes
+    - sshd_set_keepalive
 
   - id: R30
     level: minimal


### PR DESCRIPTION


#### Description:

- Select sshd_set_keepalive in ANSSI R29.

#### Rationale:

- This rule is required by sshd_set_idle_timeout and must be selected
otherwise, the OVAL check will always fail.
