### PR TITLE
Add github workflow to build content and use it in pull requests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,20 @@
+name: Build Content
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  validate:
+    name: Build Content
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install Deps
+        uses: mstksg/get-package@master
+        with:
+                apt-get: cmake ninja-build libopenscap8 libxml2-utils expat xsltproc python3-jinja2 python3-yaml ansible-lint python3-github
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Build
+        run: |
+          ./build_product rhel7 rhel8

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,3 +18,6 @@ jobs:
       - name: Build
         run: |
           ./build_product rhel7 rhel8
+      - name: Test
+        run: ctest -j2 --output-on-failure -E unique-stigids
+        working-directory: ./build

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,9 +1,9 @@
 name: Build Content
 on:
   push:
-    branches: [ master ]
+    branches: [ master, policy_source ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, policy_source ]
 jobs:
   validate:
     name: Build Content


### PR DESCRIPTION
#### Description:

- Add github workflow to build content and use it in pull requests

#### Rationale:

- Gate PRs. This can potentially be integrated into the main CaC repo in future.

~I'm not really sure if this will work. But why not.~ It works
