### PR TITLE
Remove default selector from rsyslog_remote_loghost_address in ANSSI.

### DIFF
--- a/controls/anssi.yml
+++ b/controls/anssi.yml
@@ -116,7 +116,6 @@ controls:
     rules:
     # The default remote loghost is logcollector.
     # Change the default value to the hostname or IP of the system to send the logs to
-    - rsyslog_remote_loghost_address=default
     - rsyslog_remote_loghost
 
   - id: R8
@@ -601,7 +600,6 @@ controls:
     # Derived from DAT-NT-012 R5, these are also covered in R7
     # The default remote loghost is logcollector.
     # Change the default value to the hostname or IP of the system to send the logs to
-    - rsyslog_remote_loghost_address=default
     - rsyslog_remote_loghost
 
     # Derived from DAT-NT-012 R12


### PR DESCRIPTION
#### Description:

- Remove default selector from rsyslog_remote_loghost_address in ANSSI.

#### Rationale:

- It doesn't make sense to select a value called "default" since it's not
defined in the benchmark.
